### PR TITLE
Fix admin Cr. display and calendar internal error

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,11 @@ service cloud.firestore {
       return signedIn() && request.auth.uid == uid;
     }
 
+    // Collection group rule — required for collectionGroup('entries') admin query
+    match /{path=**}/entries/{entryId} {
+      allow read: if isSuperAdmin();
+    }
+
     match /users/{userId} {
       allow read: if isOwner(userId) || isSuperAdmin();
       allow create: if isOwner(userId);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -275,7 +275,13 @@ export const getCalendarFeed = onCall(
       throw new HttpsError('unauthenticated', 'Authentication required.');
     }
 
-    const config = await loadCalendarConfig();
+    let config;
+    try {
+      config = await loadCalendarConfig();
+    } catch (error) {
+      logger.error('Failed to load calendar config', { error });
+      return { config: normalizeCalendarConfigData(null), events: [], fetchedAt: Date.now() };
+    }
     if (!config.enabled || !config.y8ContentFeedUrl.trim()) {
       return {
         config: {


### PR DESCRIPTION
## Summary
- `firestore.rules`: Add `/{path=**}/entries` wildcard rule so `collectionGroup` queries work for super admin, fixing Admin page showing 0 Cr. for all users
- `functions/src/index.ts`: Wrap `loadCalendarConfig()` in try/catch to prevent unhandled Firestore errors from surfacing as opaque `internal` HttpsError in the calendar feed

## Deploy
After merging, run:
```
git fetch origin && git reset --hard origin/main
npm run build
firebase deploy --only functions,firestore:rules,hosting
```